### PR TITLE
Captive portal experience like airplane

### DIFF
--- a/services/wifi-connect/start.sh
+++ b/services/wifi-connect/start.sh
@@ -26,15 +26,11 @@ cat <<'END_HTML' >/usr/src/app/ui/index.html
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <!-- <meta http-equiv="refresh" content="0; url=http://192.168.42.1:8080"> -->
-        <script type="text/javascript">
-            window.location.href = "http://192.168.42.1:8080"
-        </script>
-        <title>Page Redirection</title>
+        <title>Earth Defenders Toolkit Captive Portal</title>
+        <meta http-equiv="refresh" content="0; url=http://edt.local">
     </head>
     <body>
-        <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-        If you are not redirected automatically, follow this <a href='http://192.168.42.1:8080'>link to example</a>.
+        <p>If you are not redirected automatically, follow this <a href="http://edt.local">link to Earth Defenders Toolkit</a>.</p>
     </body>
 </html>
 END_HTML


### PR DESCRIPTION
### **User description**
Redirect user to default browser through the captive-portal


___

### **PR Type**
Enhancement


___

### **Description**
- Updated the captive portal HTML to use a `meta http-equiv` tag for automatic redirection.
- Changed the redirection URL to `http://edt.local`.
- Improved the user message and link in the HTML body.
- Removed the JavaScript-based redirection in favor of the `meta` tag.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start.sh</strong><dd><code>Update captive portal HTML for improved redirection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/wifi-connect/start.sh
<li>Updated HTML content to use <code>meta http-equiv</code> tag for redirection.<br> <li> Changed redirection URL to <code>http://edt.local</code>.<br> <li> Updated the link text and URL in the body.<br> <li> Removed JavaScript-based redirection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/67/files#diff-0061d0502b48b8aab8c0cbeadc6070b38327f86672437cebe676aaca376af781">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

