### PR TITLE
Auto-generate `docker-compose` files and enhance FileBrowser configuration

### DIFF
--- a/.github/workflows/balena-pr-draft.yml
+++ b/.github/workflows/balena-pr-draft.yml
@@ -27,4 +27,4 @@ jobs:
           github_head_ref: ${{ github.head_ref }}
           balena_release_type: draft
           release_tag: ${{ github.ref_name }}
-          commit: ${{ github.sha }}
+          commit: $(git rev-parse HEAD)

--- a/.github/workflows/balena-push-main.yml
+++ b/.github/workflows/balena-push-main.yml
@@ -27,4 +27,4 @@ jobs:
           github_head_ref: ${{ github.head_ref }}
           balena_release_type: draft
           release_tag: main
-          commit: ${{ github.sha }}
+          commit: $(git rev-parse HEAD)

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .balena/
-
+*.md
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-
+.docker
 # Runtime data
 pids
 *.pid

--- a/balena.yml
+++ b/balena.yml
@@ -1,6 +1,6 @@
 name: "Earth Defender's Toolkit Offline"
 type: "sw.application"
-version: 0.5.0
+version: 0.5.3
 description: "A low-energy device that creates an access-point serving applications, bridging them and exposing curated content offline.
   Software stack and content are automatically updated while online, and can be updated offline."
 assets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ volumes:
   fdroid:
   mapeo:
   crawls:
+  users:
   pywb-archive:
   installers:
   postgres_data:
@@ -78,6 +79,7 @@ services:
       - fdroid:/srv/fdroid
       - installers:/srv/installers
       - mbtiles:/srv/mbtiles
+      - users:/srv/users
       - terrastories-import:/srv/terrastories/import
       - terrastories-media:/srv/terrastories/media
     ports:
@@ -93,6 +95,7 @@ services:
       - fdroid:/data/fdroid
       - installers:/data/installers
       - mbtiles:/data/mbtiles
+      - users:/data/users
     ports:
       - 8082:8384
       - 22000:22000/tcp
@@ -154,6 +157,7 @@ services:
       - fdroid:/usr/local/apache2/htdocs/repo
       - mapeo:/usr/local/apache2/htdocs/mapeo
       - mbtiles:/usr/local/apache2/htdocs/mbtiles
+      - users:/usr/local/apache2/htdocs/users
     restart: unless-stopped
   # https://hub.docker.com/r/communityfirst/pataka-cli
   pataka:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       io.balena.features.balena-api: 1
   # https://github.com/balena-labs-research/python-wifi-connect
   wifi:
-    image: ghcr.io/balena-labs-research/python-wifi-connect:latest
+    image: communityfirst/python-wifi-connect:latest
     environment:
       PWC_HOST: bridge
       DBUS_SYSTEM_BUS_ADDRESS: "unix:path=/host/run/dbus/system_bus_socket"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       io.balena.features.balena-api: 1
   # https://github.com/balena-labs-research/python-wifi-connect
   wifi:
-    image: communityfirst/python-wifi-connect:latest
+    image: ghcr.io/balena-labs-research/python-wifi-connect:latest
     environment:
       PWC_HOST: bridge
       DBUS_SYSTEM_BUS_ADDRESS: "unix:path=/host/run/dbus/system_bus_socket"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,19 @@
 version: "2.1"
 
 volumes:
-  interface_db:
-  wifi_db:
-  syncthing:
   fdroid:
   mapeo:
   crawls:
-  users:
-  pywb-archive:
-  installers:
-  postgres_data:
   mbtiles:
+  installers:
+  pywb-archive:
+  users:
+  interface_db:
+  wifi_db:
+  syncthing:
+  postgres_data:
+  filebrowser-db:
+  filebrowser-json:
   terrastories-bundler:
   terrastories-media:
   terrastories-import:
@@ -84,6 +86,8 @@ services:
       - users:/srv/users
       - terrastories-import:/srv/terrastories/import
       - terrastories-media:/srv/terrastories/media
+      - filebrowser-db:/database.db
+      - filebrowser-json:/.filebrowser.json
     ports:
       - 8081:80
     command: -- c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ volumes:
   terrastories-media:
   terrastories-import:
   pataka:
-  photo-config:
-  photo-thumbs:
 services:
   # https://github.com/digidem/starter-interface
   balena-interface:
@@ -174,18 +172,3 @@ services:
       - pataka:/root/.local/share/ahau-pataka
     environment:
       PATAKA_WEB_PORT: 8089
-  # https://github.com/linuxserver/docker-photoshow
-  photoshow:
-    image: lscr.io/linuxserver/photoshow:latest
-    container_name: photoshow
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=Europe/London
-    volumes:
-      - photo-config:/config
-      - users:/Pictures:ro
-      - photo-thumbs:/Thumbs
-    ports:
-      - 8090:80
-    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ volumes:
   terrastories-media:
   terrastories-import:
   pataka:
+  photo-config:
+  photo-thumbs:
 services:
   # https://github.com/digidem/starter-interface
   balena-interface:
@@ -168,3 +170,18 @@ services:
       - pataka:/root/.local/share/ahau-pataka
     environment:
       PATAKA_WEB_PORT: 8089
+  # https://github.com/linuxserver/docker-photoshow
+  photoshow:
+    image: lscr.io/linuxserver/photoshow:latest
+    container_name: photoshow
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/London
+    volumes:
+      - photo-config:/config
+      - users:/Pictures:ro
+      - photo-thumbs:/Thumbs
+    ports:
+      - 8090:80
+    restart: unless-stopped

--- a/docker-stacks.yml
+++ b/docker-stacks.yml
@@ -1,0 +1,20 @@
+demo:
+  exclude:
+    labels:
+    services:
+      - python-wifi-connect
+      - balena-interface
+    volumes:
+      - wifi_db
+  include:
+    services:
+      - portal: 80
+    environment:
+      - BALENA_INTERFACE_API=http://
+local:
+  exclude:
+    labels:
+    services:
+      - balena-interface
+    volumes:
+      - interface_db

--- a/scripts/.docker/docker-compose-demo.yml
+++ b/scripts/.docker/docker-compose-demo.yml
@@ -1,0 +1,5 @@
+  portal:
+    ports:
+      - 80:80
+    environment:
+      - BALENA_INTERFACE_API=http://

--- a/scripts/.docker/docker-compose-local.yml
+++ b/scripts/.docker/docker-compose-local.yml
@@ -1,0 +1,5 @@
+  portal:
+    ports:
+      - 80:80
+    environment:
+      - BALENA_INTERFACE_API=http://balena-interface

--- a/scripts/generate-docker-stacks.sh
+++ b/scripts/generate-docker-stacks.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+# Ensure .docker directory exists
+mkdir -p .docker
+
+# Read config file
+config=$(cat ../docker-stacks.yml)
+
+# Parse YAML 
+demo_config=$(echo $config | yq .demo)
+local_config=$(echo $config | yq .local)
+
+# Demo environment 
+# Exclude services 
+sed "/python-wifi-connect/d" docker-compose.yml > .docker/docker-compose-demo.yml
+# Exclude volumes
+sed -i "/wifi_db/d" .docker/docker-compose-demo.yml
+# Include services 
+echo "  portal:
+    ports:
+      - 80:80" >> .docker/docker-compose-demo.yml
+# Include environment
+echo "    environment:" >> .docker/docker-compose-demo.yml 
+echo "      - BALENA_INTERFACE_API=http://" >> .docker/docker-compose-demo.yml
+
+# Local environment
+# Exclude services
+sed "/balena-interface/d" docker-compose.yml > .docker/docker-compose-local.yml
+# Exclude volumes 
+sed -i "/interface_db/d" .docker/docker-compose-local.yml
+# Include services
+echo "  portal:
+    ports:
+      - 80:80" >> .docker/docker-compose-local.yml
+# Include environment
+echo "    environment:" >> .docker/docker-compose-local.yml
+echo "      - BALENA_INTERFACE_API=http://balena-interface" >> .docker/docker-compose-local.yml
+# #!/bin/sh
+
+# # Read docker-compose.yml
+# # Read balena.yml file
+# # Read docker-stacks.yml
+# # Parse YAML
+# # For each environment
+# # 1. Exclude: labels, services, environments
+# # 2. Include: labels, environments
+# # TODO: include services
+
+# # Read config file
+# config=$(cat ../docker-stacks.yml)
+
+# # Parse YAML 
+# demo_config=$(echo $config | yq .demo)
+# local_config=$(echo $config | yq .local)
+
+# # Demo environment 
+# # Exclude services 
+# sed -i "/python-wifi-connect/d" docker-compose.yml 
+# # Exclude volumes
+# sed -i "/wifi_db/d" docker-compose.yml
+# # Include services 
+# echo "  portal:
+#     ports:
+#       - 80:80" >> docker-compose.yml
+# # Include environment
+# echo "    environment:" >> docker-compose.yml 
+# echo "      - BALENA_INTERFACE_API=http://" >> docker-compose.yml
+
+# # Local environment
+# # Exclude services
+# sed -i "/balena-interface/d" docker-compose.yml
+# # Exclude volumes 
+# sed -i "/interface_db/d" docker-compose.yml
+# # Include services
+# echo "  portal:
+#     ports:
+#       - 80:80" >> docker-compose.yml
+# # Include environment
+# echo "    environment:" >> docker-compose.yml
+# echo "      - BALENA_INTERFACE_API=http://balena-interface" >> docker-compose.yml
+
+# # This script:
+
+# # Reads the docker-stacks.yml config file
+# # Parses the YAML using yq to get the demo and local environment configs 
+# # For the demo environment, it excludes the python-wifi-connect service and wifi_db volume
+# # It includes the portal service and BALENA_INTERFACE_API environment variable
+# # For the local environment, it excludes the balena-interface service and interface_db volume
+# # It includes the portal service and BALENA_INTERFACE_API environment variable pointing to balena-interface
+# # It modifies the docker-compose.yml file based on these inclusions and exclusions

--- a/services/filebrowser/Dockerfile
+++ b/services/filebrowser/Dockerfile
@@ -1,4 +1,4 @@
-FROM filebrowser/filebrowser:s6
+FROM filebrowser/filebrowser:v2.23.0-s6
 
 COPY custom /config/custom
 COPY start.sh .

--- a/services/filebrowser/start.sh
+++ b/services/filebrowser/start.sh
@@ -4,6 +4,8 @@ echo "--------- Starting FileBrowser -----------"
 echo "Initiating config"
 filebrowser config init
 echo "Creating new user"
+mkdir -p /users
+chown -R 1000:1000 /users
 filebrowser users add ${ADMIN_LOGIN} ${ADMIN_PASSWORD} --perm.admin --lockPassword
 echo "Loading config file"
 echo "LOCALE: $LOCALE"

--- a/services/filebrowser/start.sh
+++ b/services/filebrowser/start.sh
@@ -4,8 +4,6 @@ echo "--------- Starting FileBrowser -----------"
 echo "Initiating config"
 filebrowser config init
 echo "Creating new user"
-mkdir -p /users
-chown -R 1000:1000 /users
 filebrowser users add ${ADMIN_LOGIN} ${ADMIN_PASSWORD} --perm.admin --lockPassword
 echo "Loading config file"
 echo "LOCALE: $LOCALE"
@@ -13,7 +11,4 @@ echo "Using user: $ADMIN_LOGIN and password: $ADMIN_PASSWORD"
 sed -i -r "s/#LOCALE/$LOCALE/g" /config/custom/filebrowser.json
 filebrowser config import /config/custom/filebrowser.json
 filebrowser config set --branding.files "/config/custom/branding"
-# if [ -n "$FILE_NOAUTH" ]; then
-#   filebrowser config set --auth.method noauth
-# fi
 filebrowser

--- a/services/filebrowser/start.sh
+++ b/services/filebrowser/start.sh
@@ -11,4 +11,5 @@ echo "Using user: $ADMIN_LOGIN and password: $ADMIN_PASSWORD"
 sed -i -r "s/#LOCALE/$LOCALE/g" /config/custom/filebrowser.json
 filebrowser config import /config/custom/filebrowser.json
 filebrowser config set --branding.files "/config/custom/branding"
+filebrowser config set --auth.method noauth
 filebrowser

--- a/services/filebrowser/start.sh
+++ b/services/filebrowser/start.sh
@@ -12,6 +12,9 @@ echo "LOCALE: $LOCALE"
 echo "Using user: $ADMIN_LOGIN and password: $ADMIN_PASSWORD"
 sed -i -r "s/#LOCALE/$LOCALE/g" /config/custom/filebrowser.json
 filebrowser config import /config/custom/filebrowser.json
-filebrowser config set --branding.files "/config/custom/branding"
-filebrowser config set --auth.method noauth
+
+if [ -n "$FILE_NOAUTH" ]; then
+  filebrowser config set --auth.method noauth
+fi
+
 filebrowser

--- a/services/filebrowser/start.sh
+++ b/services/filebrowser/start.sh
@@ -4,6 +4,8 @@ echo "--------- Starting FileBrowser -----------"
 echo "Initiating config"
 filebrowser config init
 echo "Creating new user"
+mkdir -p /users
+chown -R 1000:1000 /users
 filebrowser users add ${ADMIN_LOGIN} ${ADMIN_PASSWORD} --perm.admin --lockPassword
 echo "Loading config file"
 echo "LOCALE: $LOCALE"
@@ -11,4 +13,7 @@ echo "Using user: $ADMIN_LOGIN and password: $ADMIN_PASSWORD"
 sed -i -r "s/#LOCALE/$LOCALE/g" /config/custom/filebrowser.json
 filebrowser config import /config/custom/filebrowser.json
 filebrowser config set --branding.files "/config/custom/branding"
+if [ -n "$FILE_NOAUTH" ]; then
+  filebrowser config set --auth.method noauth
+fi
 filebrowser

--- a/services/filebrowser/start.sh
+++ b/services/filebrowser/start.sh
@@ -12,9 +12,8 @@ echo "LOCALE: $LOCALE"
 echo "Using user: $ADMIN_LOGIN and password: $ADMIN_PASSWORD"
 sed -i -r "s/#LOCALE/$LOCALE/g" /config/custom/filebrowser.json
 filebrowser config import /config/custom/filebrowser.json
-
-if [ -n "$FILE_NOAUTH" ]; then
-  filebrowser config set --auth.method noauth
-fi
-
+filebrowser config set --branding.files "/config/custom/branding"
+# if [ -n "$FILE_NOAUTH" ]; then
+#   filebrowser config set --auth.method noauth
+# fi
 filebrowser


### PR DESCRIPTION
### **User description**
Maintaing working parallel non-Balena `docker-compose.yml` files for both online **demo** and **local** deploys is challenging and very error-prone. Ideally there should be a scripts that generates them from the balena `docker-compose.yml`.


___

### **PR Type**
Enhancement, Bug fix, Other


___

### **Description**
- Added a script to auto-generate `docker-compose` files for demo and local environments.
- Enhanced FileBrowser start script to create `/users` directory and set permissions, and to disable authentication if `FILE_NOAUTH` is set.
- Fixed commit hash retrieval in GitHub Actions workflows.
- Updated application version to 0.5.3.
- Updated `docker-compose` to include new volumes and services.
- Added configuration for demo and local environments in `docker-stacks.yml`.
- Generated `docker-compose` files for demo and local environments.
- Updated FileBrowser Dockerfile to use a specific versioned base image.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-docker-stacks.sh</strong><dd><code>Add script to auto-generate <code>docker-compose</code> files for demo and local <br>environments.</code></dd></summary>
<hr>

scripts/generate-docker-stacks.sh
<li>Added script to generate <code>docker-compose</code> files for demo and local <br>environments.<br> <li> Excluded specific services and volumes for each environment.<br> <li> Included specific services and environment variables for each <br>environment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-381ea5c97d3a01b465eba5280d7a029e00d44b373c0f73370c0bc805a43e38e4">+90/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>start.sh</strong><dd><code>Enhance FileBrowser start script with user directory and no-auth </code><br><code>option.</code></dd></summary>
<hr>

services/filebrowser/start.sh
<li>Added creation and permission setting for <code>/users</code> directory.<br> <li> Added conditional check for <code>FILE_NOAUTH</code> environment variable to <br>disable authentication.<br>


</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-e76050f6442d8739947c293b94990141cf2155075fe6092cdfb8a08b44fb04a3">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update `docker-compose` with new volumes and services.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml
<li>Added new volumes: <code>users</code>, <code>filebrowser-db</code>, <code>filebrowser-json</code>.<br> <li> Updated services to include new volumes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+13/-5</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-stacks.yml</strong><dd><code>Add configuration for demo and local environments.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-stacks.yml
<li>Added configuration for demo and local environments.<br> <li> Defined services and volumes to exclude/include for each environment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-e7f0829ad9c51b03d2e2ba85ac5c23312962b6074a80cd73aad620eb2ed14567">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-demo.yml</strong><dd><code>Add generated `docker-compose` file for demo environment.</code></dd></summary>
<hr>

scripts/.docker/docker-compose-demo.yml
- Generated `docker-compose` file for demo environment.



</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-b01c8e81b5d5ae3aca45574764bd842329c1c87e527fd685600b62c934820939">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-local.yml</strong><dd><code>Add generated `docker-compose` file for local environment.</code></dd></summary>
<hr>

scripts/.docker/docker-compose-local.yml
- Generated `docker-compose` file for local environment.



</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-b81b935385e5e1f9dba7526e1677b7646c762e55e8ee4025a2d3f7b220e66f34">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update FileBrowser Dockerfile base image.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/filebrowser/Dockerfile
- Updated base image to `filebrowser/filebrowser:v2.23.0-s6`.



</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-9e0dc9be6666b48955e7a46fa0518c69e12d2d984aaa7948c79a3b5f9d0a17a8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>balena-pr-draft.yml</strong><dd><code>Fix commit hash retrieval in GitHub Actions workflow.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/balena-pr-draft.yml
- Fixed commit hash retrieval to use `git rev-parse HEAD`.



</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-d7acefdba75e34f6e0f3b3764cd51470913d3141e39294cae4681c9a411fe671">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>balena-push-main.yml</strong><dd><code>Fix commit hash retrieval in GitHub Actions workflow.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/balena-push-main.yml
- Fixed commit hash retrieval to use `git rev-parse HEAD`.



</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-0794fab0a48c2cd66e8d1b2ecd77f0acda66d18468319df3a34a00e58ed78ad6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Other
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>balena.yml</strong><dd><code>Update application version to 0.5.3.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

balena.yml
- Updated version from `0.5.0` to `0.5.3`.



</details>
    

  </td>
  <td><a href="https://github.com/digidem/edt-offline/pull/68/files#diff-8448e809945865b05ca68634bac731b7197e4631eebe6531f849cb56918e6908">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

